### PR TITLE
Fix Qualimap on Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ A. configのプロジェクトIDやサンプルIDが正しいか、ネットワ�
 ### Q. BAM/VCF等の出力がない
 A. ログファイル（`data/logs/`）を確認し、エラー内容を特定してください。
 
+### Q. Qualimap 実行時に `Unrecognized VM option 'MaxPermSize=1024m'` と表示される
+A. Java 9 以降では `-XX:MaxPermSize` オプションが廃止されており、Qualimap が起動に失敗することがあります。
+   `modules/analyzers.py` では Java 17 でも動作するよう `JAVA_TOOL_OPTIONS=-XX:+IgnoreUnrecognizedVMOptions` を自動で指定しますが、
+   手動で Qualimap を実行する場合は以下のように環境変数を付与してください:
+   ```sh
+   JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions" qualimap bamqc ...
+   ```
+
 **備考:**  
 - 詳細な使い方やパラメータ説明は、`config.py`や各モジュールのdocstringを参照してください。
 - 実際の解析例や出力例も追記可能です。

--- a/modules/analyzers.py
+++ b/modules/analyzers.py
@@ -1,3 +1,4 @@
+import os
 import shlex
 import subprocess
 import logging
@@ -106,8 +107,13 @@ class QualimapAnalyzer:
             "-outformat", "HTML",
             "--java-mem-size=8G",
         ]
+        env = os.environ.copy()
+        # Java 9+ no longer recognizes -XX:MaxPermSize, which Qualimap still adds
+        # in its launch script. The following option tells the JVM to ignore
+        # any unsupported -XX arguments so Qualimap can run under Java 17.
+        env["JAVA_TOOL_OPTIONS"] = env.get("JAVA_TOOL_OPTIONS", "") + " -XX:+IgnoreUnrecognizedVMOptions"
         try:
-            subprocess.run(qualimap_cmd, check=True)
+            subprocess.run(qualimap_cmd, check=True, env=env)
             logger.info(f"Qualimap completed for {sample_acc}")
             return sample_outdir
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- ignore unsupported MaxPermSize option so Qualimap works with newer JVMs
- document workaround in FAQ

## Testing
- `python3 -m py_compile config.py main.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688b35c617c08324b9ad8822c8c6737c